### PR TITLE
only use one client

### DIFF
--- a/api/jagw_connector/connector.go
+++ b/api/jagw_connector/connector.go
@@ -8,14 +8,10 @@ import (
 	"google.golang.org/grpc"
 )
 
-/*
-TODO:
-A better way to connect to GRPC should be found.
-Unfortunately the defer function closes the connection to early and I don't want to clutter the main.go
-*/
 var rsConnection *grpc.ClientConn
+var rsClient jagw.RequestServiceClient
 
-func getJagwRequestClient() jagw.RequestServiceClient {
+func GetJagwRequestClient() {
 	config := configs.LoadConfig()
 	requestServiceEndpoint := jagw.JagwEndpoint{
 		EndpointAddress: config.JAGW.Server,
@@ -26,11 +22,9 @@ func getJagwRequestClient() jagw.RequestServiceClient {
 	if rsErr != nil {
 		log.Fatalf("Failed to setup request service connection: %s", rsErr)
 	}
-	// defer rsConnection.Close()
-
-	return jagw.NewRequestServiceClient(rsConnection)
+	rsClient = jagw.NewRequestServiceClient(rsConnection)
 }
 
-func closeJagwRequestClient() {
+func CloseJagwRequestClient() {
 	rsConnection.Close()
 }

--- a/api/jagw_connector/edges.go
+++ b/api/jagw_connector/edges.go
@@ -12,13 +12,10 @@ func GetAllLinks() *jagw.LsNodeEdgeResponse {
 	var response *jagw.LsNodeEdgeResponse
 	var err error
 
-	client := getJagwRequestClient()
-	defer closeJagwRequestClient()
-
 	request := &jagw.TopologyRequest{}
 
 	for i := 0; i < 3; i++ {
-		response, err = client.GetLsNodeEdges(context.Background(), request)
+		response, err = rsClient.GetLsNodeEdges(context.Background(), request)
 		if err == nil {
 			break
 		}

--- a/api/jagw_connector/nodes.go
+++ b/api/jagw_connector/nodes.go
@@ -12,13 +12,10 @@ func GetAllNodes() *jagw.LsNodeResponse {
 	var response *jagw.LsNodeResponse
 	var err error
 
-	client := getJagwRequestClient()
-	defer closeJagwRequestClient()
-
 	request := &jagw.TopologyRequest{}
 
 	for i := 0; i < 3; i++ {
-		response, err = client.GetLsNodes(context.Background(), request)
+		response, err = rsClient.GetLsNodes(context.Background(), request)
 		if err == nil {
 			break
 		}

--- a/api/main.go
+++ b/api/main.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"network_graph_api/handlers"
+	"network_graph_api/jagw_connector"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 )
 
 func main() {
+
+	jagw_connector.GetJagwRequestClient()
+	defer jagw_connector.CloseJagwRequestClient()
 
 	router := gin.Default()
 	config := cors.DefaultConfig()


### PR DESCRIPTION
Only use one client for all operations, improves the stability considerably